### PR TITLE
Add support for mileseey tr256e and topdon tc004

### DIFF
--- a/example.py
+++ b/example.py
@@ -14,8 +14,9 @@ fine_plt = ax2.imshow(fine)
 ax2.set_title('Fine absolute temperatures')
 fig.colorbar(fine_plt, ax=ax2, location='right', label='degrees Celsius')
 
-ax3.imshow(vis)
-ax3.set_title('Visual')
+if vis:
+    ax3.imshow(vis)
+    ax3.set_title('Visual')
 
 ax4.hist(fine.flatten(), bins=100)
 ax4.set_title('Temperature histogram')

--- a/src/infiray_irg.py
+++ b/src/infiray_irg.py
@@ -45,7 +45,7 @@ def load(data, print_debug_information=False):
     # file.
     fine_temp_offset1, fine_temp_offset2, distance, *rest, unit_flag, high_gain_mode_flag = struct.unpack('<9IHHI', header[34:78])
     distance /= 1e4
-    
+
     if fine_temp_offset1 != fine_temp_offset2:
         warnings.warn(f'File lists two different zero offsets for the fine image data {fine_temp_offset1} and {fine_temp_offset2}. Resulting radiometric data might be offset. Please report this with an example file to code@jaseg.de.')
 
@@ -60,7 +60,7 @@ def load(data, print_debug_information=False):
 
     if x_res*y_res != coarse_section_length:
         raise ValueError('Resolution mismatch in header')
-        
+
     vis_jpg = None
     coarse_img = np.frombuffer(consume(coarse_section_length), dtype=np.uint8).reshape((y_res, x_res))
     fine_img = np.frombuffer(consume(x_res*y_res*2), dtype=np.uint16).reshape((y_res, x_res))
@@ -96,6 +96,5 @@ def load(data, print_debug_information=False):
         fine_img = fine_img / 10 - 273.2
 
         # In my example file, data now contains the JSON '{"roi":[]}' and no JPG. We ignore that.
-    
-    return coarse_img, fine_img, vis_jpg
 
+    return coarse_img, fine_img, vis_jpg

--- a/src/infiray_irg.py
+++ b/src/infiray_irg.py
@@ -30,6 +30,7 @@ def load(data, print_debug_information=False):
             'c201': bytes([0xca, 0xac]),
             'other': bytes([0xba, 0xab]),
             'p200': bytes([0x04, 0xa0]),
+            'tc004-tr256e' : bytes([0xb0, 0x0b]),
             }.items():
         if (header[:2] + header[-2:]).startswith(match):
             break
@@ -91,7 +92,8 @@ def load(data, print_debug_information=False):
         fine_img = fine_img / 10 - 273.15
 
         vis_jpg = Image.open(io.BytesIO(data))
-
+    elif model == 'tc004-tr256e':
+        fine_img = fine_img / 10 - 273.1
     else:
         fine_img = fine_img / 10 - 273.2
 


### PR DESCRIPTION
I own a Mileseey tr256e. I've shot some thermal images with it - as it is has been sold. Then, due to lack of certain features I needed, I ended up in hacking it and loading the Topdon tc004 firmware on it (I guessed the HW is the same) 

Both images I shot before update and after update seem to have same header and thermal data. 

In this PR I added some bits to make the library recognize the new header magics and convert thermal pixel in proper scale. I've also made a quick and dirty fix to the example program to avoid crash when visible data is not present (note that both cameras have no visible light sensor).

Regarding the scaling calculations (i.e. proper constant), I've tried with both I saw in your code (i.e. "c210" and "other" cases); I ended up to find out a slightly different value by trial and error by comparing the hottest/coldest pixel output result from the example program wrt the max/min scale overlaid in the jpg images saved by the camera. 

All images are taken in the lower scale supported by the camera (-20 - 150 C). Never tried with the other one (IIRC 100-400 C); I may try later on.

I attach the JPG and IRG images files. Unfortunately I haven't any really high contrast image taken before firmware update. The one I attach here is the best I have.

[images.zip](https://github.com/user-attachments/files/19618655/images.zip)
